### PR TITLE
Fix/base branch modified

### DIFF
--- a/src/commands/label-merge.ts
+++ b/src/commands/label-merge.ts
@@ -6,6 +6,47 @@ import { sleep } from "../utils/sleep";
 import { listMergeConflicts } from "../utils/listMergeConflicts";
 import { config } from "../config";
 
+async function merge(
+  // @ts-ignore
+  octokit,
+  owner: string,
+  repo: string,
+  prNum: number,
+  base: string,
+  label: string
+) {
+  try {
+    await octokit.pulls.merge({
+      owner,
+      repo,
+      pull_number: prNum,
+      base: base,
+    });
+
+    console.log(`Successfully merged: PR#${prNum}`);
+    config.set(`${owner}:${repo}:recent-branch`, base.trim());
+  } catch (error) {
+    const hasMergeConflicts = await listMergeConflicts(
+      octokit,
+      owner,
+      repo,
+      label
+    );
+
+    if (!hasMergeConflicts) {
+      if (
+        error.message ===
+        "Base branch was modified. Review and try the merge again."
+      ) {
+        console.log(prNum);
+        await sleep(3000);
+        await merge(octokit, owner, repo, prNum, base, label);
+      }
+    }
+    // process.exit(0);
+  }
+}
+
 export default class LabelMerge extends Command {
   static description =
     "🔍 finds all open PRs tagged with label {X} on a repo and merge them into branch {Y}";
@@ -70,36 +111,24 @@ export default class LabelMerge extends Command {
               base: flags.branch,
             });
           } catch (error) {
-            console.log(error.message);
+            // console.log(error.message);
+
             process.exit(0);
           }
         });
+
         // merges them
         pullsWithLabels.map(async (el) => {
           // to avoid rate-limiting
           await sleep(3000);
-          try {
-            await octokit.pulls.merge({
-              owner,
-              repo,
-              pull_number: el.number,
-              base: flags.branch,
-            });
-            console.log(`Successfully merged: PR#${el.number}`);
-            config.set(`${owner}:${repo}:recent-branch`, flags.branch.trim());
-          } catch (error) {
-            const hasMergeConflicts = await listMergeConflicts(
-              octokit,
-              owner,
-              repo,
-              flags.label
-            );
-
-            if (!hasMergeConflicts) {
-              console.log(error.message);
-            }
-            // process.exit(0);
-          }
+          await merge(
+            octokit,
+            owner,
+            repo,
+            el.number,
+            flags.branch,
+            flags.label
+          );
         });
       } else {
         console.log("no open PRs with that label");

--- a/src/commands/label-merge.ts
+++ b/src/commands/label-merge.ts
@@ -38,7 +38,6 @@ async function merge(
         error.message ===
         "Base branch was modified. Review and try the merge again."
       ) {
-        console.log(prNum);
         await sleep(3000);
         await merge(octokit, owner, repo, prNum, base, label);
       }

--- a/src/utils/getRemoteOwners.ts
+++ b/src/utils/getRemoteOwners.ts
@@ -13,9 +13,6 @@ export async function getRemoteOwners() {
     const remote = newRemotes[0].refs.push;
 
     const parsedUrl = gh(remote);
-    console.log(parsedUrl);
-    console.log(parsedUrl.owner);
-    console.log(parsedUrl.name);
     return [parsedUrl.owner, parsedUrl.name];
   } else {
     console.log("remote must include github");

--- a/src/utils/listMergeConflicts.ts
+++ b/src/utils/listMergeConflicts.ts
@@ -59,7 +59,10 @@ export async function listMergeConflicts(
       });
 
       const { data: prData } = data;
-      if (!prData.mergeable) {
+      // mergeable !== null
+      // means branch is still in the process of
+      // checking for base branch changes.
+      if (!prData.mergeable && prData.mergeable !== null) {
         hasMergeConflicts = true;
         console.log("Failed to merge");
         console.log(`${prData.head.label} -> ${prData.base.label}`);


### PR DESCRIPTION
Resolves #2 

`Base branch was modified. Review and try the merge again.` occurs when there are changes to the target or base branch. For example, we have three pull requests. When the first successfully merges, the base branch is, in turn, modified, so succeeding merges will fail as GitHub will have to check the mergeability of the pull request.  

I had two possible solutions:

1. After merging one pull request, unmerged PRs will be placed in a queue. Then, code execution will be halted until all checks and merging have been resolved with each value in the queue:
    1. Perform a `GET` request to check if the PR's mergeability status has been resolved to `true` or `false.`
    2. If the mergeability is a non-null value, proceed with the merging.
    3. Go back to the start of the flow.

2. Call a recursive retry function every time the error is `Base modified....`.

I went with solution 2. The flow was easier to reason with, and the only code I had to modify was a function extraction (`merge`).  